### PR TITLE
Fix for running in a Xen virtual machine

### DIFF
--- a/arch/x86/xen/smp.c
+++ b/arch/x86/xen/smp.c
@@ -58,6 +58,8 @@ static irqreturn_t xen_reschedule_interrupt(int irq, void *dev_id)
 	inc_irq_stat(irq_resched_count);
 	scheduler_ipi();
 
+	sched_state_ipi();
+
 	return IRQ_HANDLED;
 }
 


### PR DESCRIPTION
When using LITMUS RT on a virtual machine, migrations of tasks
between VCPUs may occur.  When this occurs, an IPI is needed
to notify the new VCPU to reschedule.  The current version
does not do so.

This patch adds in a call to sched_state_ipi() in the IPI handler,
similarly to how it is implemented in the x86 version. As far as we
can tell, the patch displays expected behavior.