### PR TITLE
Avoid errors when compiling kernel (New C warnings)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,6 +629,7 @@ include arch/$(SRCARCH)/Makefile
 
 KBUILD_CFLAGS	+= $(call cc-option,-fno-delete-null-pointer-checks,)
 KBUILD_CFLAGS	+= $(call cc-disable-warning,frame-address,)
+KBUILD_CFLAGS  += $(call cc-disable-warning, attribute-alias)
 
 ifdef CONFIG_LD_DEAD_CODE_DATA_ELIMINATION
 KBUILD_CFLAGS	+= $(call cc-option,-ffunction-sections,)

--- a/tools/lib/str_error_r.c
+++ b/tools/lib/str_error_r.c
@@ -19,8 +19,12 @@
  */
 char *str_error_r(int errnum, char *buf, size_t buflen)
 {
-	int err = strerror_r(errnum, buf, buflen);
-	if (err)
-		snprintf(buf, buflen, "INTERNAL ERROR: strerror_r(%d, %p, %zd)=%d", errnum, buf, buflen, err);
-	return buf;
+        int err = strerror_r(errnum, buf, buflen);
+        char *excep = buf;
+ 
+        if (err)
+                snprintf(excep, buflen, "INTERNAL ERROR: strerror_r(%d, %p, %zd)=%d", errnum, buf, buflen, err);
+        return buf;
 }
+
+

--- a/tools/lib/subcmd/pager.c
+++ b/tools/lib/subcmd/pager.c
@@ -29,10 +29,15 @@ static void pager_preexec(void)
 	 * have real input
 	 */
 	fd_set in;
-
+        fd_set exception;
+	
 	FD_ZERO(&in);
+	FD_ZERO(&exception);
+	
 	FD_SET(0, &in);
-	select(1, &in, NULL, &in, NULL);
+	FD_SET(0, &exception);
+	
+	select(1, &in, NULL, &exception, NULL);
 
 	setenv("LESS", "FRSX", 0);
 }


### PR DESCRIPTION
Doing $make bzImage using a .config file from kernel 4.9 gives now the following warning that prevents from compiling:

```
pager.c: In function ‘pager_preexec’:
pager.c:35:12: error: passing argument 2 to restrict-qualified parameter aliases with argument 4 [-Werror=restrict]
  select(1, &in, NULL, &in, NULL);
```
and another Warning of the same nature:

```
../lib/str_error_r.c:24:3: error: passing argument 1 to restrict-qualified parameter aliases with argument 5 [-Werror=restrict]
   snprintf(buf, buflen, "INTERNAL ERROR: strerror_r(%d, %p, %zd)=%d", errnum, buf, buflen, err);
   ^~~~~~~~
``` 


This fix it. See https://lore.kernel.org/lkml/20180101105626.7168-1-sergey.senozhatsky@gmail.com/#r for more information.