### PR TITLE
Optimization at picking next task

### DIFF
--- a/kernel/sched/litmus.c
+++ b/kernel/sched/litmus.c
@@ -286,7 +286,7 @@ static struct task_struct *pick_next_task_litmus(struct rq *rq,
 	 * provide a task, and if we find one, call put_prev_task() on the
 	 * previously scheduled task.
 	 */
-	if (next)
+	if (next && !is_realtime(next))
 		put_prev_task(rq, prev);
 
 	return next;


### PR DESCRIPTION
The function put_prev_task_litmus does nothing (located at the LITMUS^RT scheduling class).
Meanwhile, function put_prev_task at /litmus-rt/kernel/sched/sched.h only calls: 
```
prev->sched_class->put_prev_task(rq, prev);
```
So this is a way of saving some time.